### PR TITLE
Change installation step to go install @latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ permissions on the target service.
 1.  Install the proxy:
 
     ```sh
-    go get github.com/GoogleCloudPlatform/cloud-run-proxy
+    go install github.com/GoogleCloudPlatform/cloud-run-proxy@latest
     ```
 
 1.  Start the proxy:


### PR DESCRIPTION
If I don't have the repo cloned, running `go get github.com/GoogleCloudPlatform/cloud-run-proxy` results into the following:

```console
bruno@pop-os ~/GitHub> go get github.com/GoogleCloudPlatform/cloud-run-proxy                                                                                                                                                                                                                                          (base) 
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
bruno@pop-os ~/GitHub [1]>                         
```

As as user I would preferably see a `go install` reference to avoid having to clone the repo.
