### PR TITLE
Add support for http2 and grpc by enabling h2c

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/GoogleCloudPlatform/cloud-run-proxy
 go 1.19
 
 require (
+	golang.org/x/net v0.7.0
 	golang.org/x/oauth2 v0.5.0
 	google.golang.org/api v0.110.0
 )
@@ -14,7 +15,6 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect


### PR DESCRIPTION
Add -http2 flag to allow incoming connections on HTTP2 without TLS (h2c) and forwards request to HTTP2

This is fully compatible with [`grpcurl`](https://github.com/fullstorydev/grpcurl ) command by using `-plaintext` and all other tools/libraries that support HTTP2 without TLS (h2c).

Fixes #22 