### PR TITLE
Use X-Serverless-Authorization instead of Authorization header

### DIFF
--- a/main.go
+++ b/main.go
@@ -233,7 +233,7 @@ func buildProxy(host, bind *url.URL, tokenSource oauth2.TokenSource, enableHttp2
 		}
 
 		// Set the bearer token to be the id token
-		r.Header.Set("Authorization", "Bearer "+idToken)
+		r.Header.Set("X-Serverless-Authorization", "Bearer "+idToken)
 	}
 
 	// Configure error handling.

--- a/main_test.go
+++ b/main_test.go
@@ -49,7 +49,7 @@ func TestBuildProxy(t *testing.T) {
 	mux := http.NewServeMux()
 	called := false
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		if got, want := r.Header.Get("Authorization"), "Bearer mytoken"; got != want {
+		if got, want := r.Header.Get("X-Serverless-Authorization"), "Bearer mytoken"; got != want {
 			t.Errorf("invalid authorization header: expected %q to be %q", got, want)
 		}
 		called = true
@@ -178,7 +178,7 @@ func TestHttp2(t *testing.T) {
 	mux := http.NewServeMux()
 	called := false
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		if got, want := r.Header.Get("Authorization"), "Bearer mytoken"; got != want {
+		if got, want := r.Header.Get("X-Serverless-Authorization"), "Bearer mytoken"; got != want {
 			t.Errorf("invalid authorization header: expected %q to be %q", got, want)
 		}
 		called = true


### PR DESCRIPTION
The usage of X-Serverless-Authorization in the cloud-run-proxy will prevent conflicts with the actual cloud run applications authentication/authorization flow.

If the Authorization header is overwritten by cloud-run-proxy it will in some applications conflict with the app's own authorization logic resulting in an unauthorized request.

X-Serverless-Authorization is a header supported by Identity-Aware-Proxy and it is also supported for google cloud run IAM authorization. If X-Serverless-Authorization and Authorization are both present, cloud run will use X-Serverless-Authorization for authorizing the user and resolving their IAM permissions.